### PR TITLE
Add SandBase CLI to Library

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -177,6 +177,7 @@ August 20, 2026 at 01:37:10 AM UTC
 - [WritBase](https://github.com/Writbase/writbase) - MCP-native task management for AI agent fleets. Multi-agent permissions, full provenance, inter-agent task delegation, and A2A protocol alignment.
 - [Roundtable](https://github.com/sinaneshat/roundtable-dashboard) - Multi-model AI brainstorming MCP server — consult a council of AI models that debate your question, then a moderator synthesizes the best answer. 13 tools including consult_council, review_code, debug_issue, design_architecture, plan_implementation, and assess_tradeoffs. Remote endpoint: `https://mcp.roundtable.now/mcp`.
 - [operant-mcp](https://github.com/operantlabs/operant-mcp) - Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment.
+- [SandBase CLI](https://github.com/sandbaseai/cli) - Local six-tool MCP bridge for 25 AI clients to discover and run 2,000+ AI models and APIs.
 
 ## Tutorial
 


### PR DESCRIPTION
## Summary

Add SandBase CLI to the Library section as a local MCP bridge for AI model discovery and execution.

## Why it fits

- Open source under Apache-2.0
- Provides six local MCP tools
- Supports 25 AI clients
- Exposes discovery and execution across 2,000+ AI models and APIs

## Validation

- Confirmed there is no existing SandBase entry or open SandBase PR
- Added one README line only
- `git diff --check` passes

## Disclosure

I am affiliated with SandBase. AI assistance was used, and the submission was reviewed before opening this PR.
