### PR TITLE
Add Pocket Drives to Library

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -177,6 +177,7 @@ August 21, 2026 at 01:41:59 AM UTC
 - [WritBase](https://github.com/Writbase/writbase) - MCP-native task management for AI agent fleets. Multi-agent permissions, full provenance, inter-agent task delegation, and A2A protocol alignment.
 - [Roundtable](https://github.com/sinaneshat/roundtable-dashboard) - Multi-model AI brainstorming MCP server — consult a council of AI models that debate your question, then a moderator synthesizes the best answer. 13 tools including consult_council, review_code, debug_issue, design_architecture, plan_implementation, and assess_tradeoffs. Remote endpoint: `https://mcp.roundtable.now/mcp`.
 - [operant-mcp](https://github.com/operantlabs/operant-mcp) - Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment.
+- [Pocket Drives](https://github.com/RevList/pocket-drives-mcp) - Search, quote, and browse luxury, exotic, and EV rentals from independent hosts. Location autocomplete, availability, and airport or venue delivery. Remote Streamable HTTP (no auth): `https://pocketdrives.ai/mcp`. Booking finishes in the iOS app.
 
 ## Tutorial
 


### PR DESCRIPTION
Adds Pocket Drives to the Library section.

- Listing repo: https://github.com/RevList/pocket-drives-mcp
- Remote Streamable HTTP (no auth): https://pocketdrives.ai/mcp
- Official registry: `ai.pocketdrives/pocket-drives`

Pocket Drives is a P2P luxury/exotic/EV rental marketplace. Independent hosts; PocketList Inc builds the platform. This server searches, quotes, and browses. Booking finishes in the iOS app.

Single new Library bullet only. Fits this list's transport / travel focus.