### PR TITLE
Add OrkasVideoStudio MCP toolkit

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -177,6 +177,7 @@ August 25, 2026 at 01:37:59 AM UTC
 - [WritBase](https://github.com/Writbase/writbase) - MCP-native task management for AI agent fleets. Multi-agent permissions, full provenance, inter-agent task delegation, and A2A protocol alignment.
 - [Roundtable](https://github.com/sinaneshat/roundtable-dashboard) - Multi-model AI brainstorming MCP server — consult a council of AI models that debate your question, then a moderator synthesizes the best answer. 13 tools including consult_council, review_code, debug_issue, design_architecture, plan_implementation, and assess_tradeoffs. Remote endpoint: `https://mcp.roundtable.now/mcp`.
 - [operant-mcp](https://github.com/operantlabs/operant-mcp) - Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment.
+- [OrkasVideoStudio](https://github.com/Orkas-AI/Orkas-VideoStudio) - Local-first TypeScript CLI and MCP toolkit for composing, editing, and assembling videos from editable plan.json timelines.
 
 ## Tutorial
 


### PR DESCRIPTION
Adds the MIT TypeScript video-production CLI and MCP toolkit to Library using the canonical source repository.

Validation: duplicate search and git diff --check passed. No npm publication claim is made.

Disclosure: I am submitting this on behalf of the Orkas project.