### PR TITLE
Add SandBase CLI to MCP library

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -182,6 +182,7 @@ August 28, 2026 at 10:54:02 AM UTC
 - [WritBase](https://github.com/Writbase/writbase) - MCP-native task management for AI agent fleets. Multi-agent permissions, full provenance, inter-agent task delegation, and A2A protocol alignment.
 - [Roundtable](https://github.com/sinaneshat/roundtable-dashboard) - Multi-model AI brainstorming MCP server — consult a council of AI models that debate your question, then a moderator synthesizes the best answer. 13 tools including consult_council, review_code, debug_issue, design_architecture, plan_implementation, and assess_tradeoffs. Remote endpoint: `https://mcp.roundtable.now/mcp`.
 - [operant-mcp](https://github.com/operantlabs/operant-mcp) - Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment.
+- [SandBase CLI](https://github.com/sandbaseai/cli) - Local MCP server and CLI with six tools for discovering and running 2,000+ AI models through one API.
 
 ## Tutorial
 


### PR DESCRIPTION
Adds SandBase CLI as a documented MCP library/tool.

- Canonical repository: https://github.com/sandbaseai/cli
- Local MCP server and CLI with six tools
- Supports discovery and execution across 2,000+ AI models through one API

Disclosure: I contribute to sandbaseai/cli. The entry is a single concise resource addition for maintainer review.